### PR TITLE
Document change to craft.app.request.isPreview

### DIFF
--- a/changes-in-craft-3.md
+++ b/changes-in-craft-3.md
@@ -290,7 +290,7 @@ Some template functions have been deprecated in Craft 3, and will be completely 
 | `craft.request.isPut()`                                 | `craft.app.request.isPut`
 | `craft.request.isAjax()`                                | `craft.app.request.isAjax`
 | `craft.request.isSecure()`                              | `craft.app.request.isSecureConnection`
-| `craft.request.isLivePreview()`                         | `craft.app.request.isLivePreview`
+| `craft.request.isLivePreview()`                         | `craft.app.request.isPreview`
 | `craft.request.getScriptName()`                         | `craft.app.request.scriptFilename`
 | `craft.request.getPath()`                               | `craft.app.request.pathInfo`
 | `craft.request.getUrl()`                                | `url(craft.app.request.pathInfo)`


### PR DESCRIPTION
In v3.2.1, `isLivePreview` was deprecated, leaving this page out of date with differences from Craft 2.