### PR TITLE
Update getting-started.md

### DIFF
--- a/fr/testing/testing-craft/getting-started.md
+++ b/fr/testing/testing-craft/getting-started.md
@@ -80,14 +80,10 @@ These variables are explained [here](../framework/config-options.md)
 Create a `.env` file in `tests/` and ensure the following variables are setup:
 
 ```dotenv
-DB_DRIVER=""
-DB_SERVER=""
-DB_USER=""
+DB_DSN="mysql:host=<host>;port=<port>;dbname=<dbname>"
+DB_USER="root"
 DB_PASSWORD=""
-DB_DATABASE=""
-DB_SCHEMA=""
 DB_TABLE_PREFIX=""
-DB_PORT=""
 SECURITY_KEY=""
 DEFAULT_SITE_URL="https://your-site-url.test/" # Set this to the `entryUrl` param in the `codeception.yml` file.
 ```

--- a/ja/testing/testing-craft/getting-started.md
+++ b/ja/testing/testing-craft/getting-started.md
@@ -80,14 +80,10 @@ These variables are explained [here](../framework/config-options.md)
 Create a `.env` file in `tests/` and ensure the following variables are setup:
 
 ```dotenv
-DB_DRIVER=""
-DB_SERVER=""
-DB_USER=""
+DB_DSN="mysql:host=<host>;port=<port>;dbname=<dbname>"
+DB_USER="root"
 DB_PASSWORD=""
-DB_DATABASE=""
-DB_SCHEMA=""
 DB_TABLE_PREFIX=""
-DB_PORT=""
 SECURITY_KEY=""
 DEFAULT_SITE_URL="https://your-site-url.test/" # Set this to the `entryUrl` param in the `codeception.yml` file.
 ```

--- a/testing/testing-craft/getting-started.md
+++ b/testing/testing-craft/getting-started.md
@@ -80,14 +80,10 @@ These variables are explained [here](../framework/config-options.md)
 Create a `.env` file in `tests/` and ensure the following variables are setup:
 
 ```dotenv
-DB_DRIVER=""
-DB_SERVER=""
-DB_USER=""
+DB_DSN="mysql:host=localhost;port=3306;dbname=craft-test"
+DB_USER="root"
 DB_PASSWORD=""
-DB_DATABASE=""
-DB_SCHEMA=""
 DB_TABLE_PREFIX=""
-DB_PORT=""
 SECURITY_KEY=""
 DEFAULT_SITE_URL="https://your-site-url.test/" # Set this to the `entryUrl` param in the `codeception.yml` file.
 ```
@@ -157,14 +153,11 @@ add a `db.php` file in `tests/_craft/config/` and fill it with the following:
 <?php
 
 return [
-    'password' => getenv('DB_PASSWORD'),
+    'dsn' => getenv('DB_DSN'),
     'user' => getenv('DB_USER'),
-    'database' => getenv('DB_DATABASE'),
-    'tablePrefix' => getenv('DB_TABLE_PREFIX'),
-    'driver' => getenv('DB_DRIVER'),
-    'port' => getenv('DB_PORT'),
+    'password' => getenv('DB_PASSWORD'),
     'schema' => getenv('DB_SCHEMA'),
-    'server' => getenv('DB_SERVER'),
+    'tablePrefix' => getenv('DB_TABLE_PREFIX'),
 ];
 ```
 

--- a/testing/testing-craft/getting-started.md
+++ b/testing/testing-craft/getting-started.md
@@ -80,7 +80,7 @@ These variables are explained [here](../framework/config-options.md)
 Create a `.env` file in `tests/` and ensure the following variables are setup:
 
 ```dotenv
-DB_DSN="mysql:host=localhost;port=3306;dbname=craft-test"
+DB_DSN="mysql:host=<host>;port=<port>;dbname=<dbname>"
 DB_USER="root"
 DB_PASSWORD=""
 DB_TABLE_PREFIX=""


### PR DESCRIPTION
Sync db settings with the one used by Craft itself. I just followed the steps in this guide and it did not work as the database settings are not working. The Craft test app does not set the connection dns and relies on it to be set by the configuration (See `createDbConfig` https://github.com/craftcms/cms/blob/develop/src/test/Craft.php#L324).