### PR TITLE
Fixed documentation for filterByValue

### DIFF
--- a/dev/filters.md
+++ b/dev/filters.md
@@ -378,7 +378,7 @@ When an arrow function is passed, this works identically to Twig’s core [`filt
 
 ## `filterByValue`
 
-Runs an array through <api:craft\helpers\ArrayHelper::filterByValue()>.
+Runs an array through <api:craft\helpers\ArrayHelper::where()>.
 
 ## `group`
 


### PR DESCRIPTION
As of Craft 3.2, filterByValue has been deprecated. The actual Twig filter has already been updated to `where()` in Craft, the docs are just not up to date.