### PR TITLE
Typo in datetime year

### DIFF
--- a/dev/filters.md
+++ b/dev/filters.md
@@ -320,7 +320,7 @@ Possible `format` values are:
 | `short`              | 12/20/1990, 5:00 PM                            |
 | `medium` _(default)_ | Dec 20, 1990, 5:00:00 PM                       |
 | `long`               | December 20, 1990 at 5:00:00 PM PDT            |
-| `full`               | Thursday, December 20, 19909 at 5:00:00 PM PDT |
+| `full`               | Thursday, December 20, 1990 at 5:00:00 PM PDT |
 
 The current application locale will be used by default. If you want to format the date and time for a different locale, use the `locale` argument:
 


### PR DESCRIPTION
I assume it should be 1990 instead of 19909