### PR TITLE
Fixed the image not be displayed in service page.

### DIFF
--- a/ja/extend/services.md
+++ b/ja/extend/services.md
@@ -78,7 +78,7 @@ Craft には、2つの一般的なモデル操作メソッドがあります。
 
 クラス指向メソッドの制御フロー図です。
 
-!\[An example flow for a saveRecipe() method.\](../images/save-component--class.png =612x1176)
+![An example flow for a saveRecipe() method.](../../images/save-component--class.png =612x1176)
 
 ::: tip
 操作が複数データベースの変更を含む場合、データベーストランザクションで操作をラップする必要があるだけです。
@@ -118,7 +118,7 @@ public function saveRecipe(Recipe $recipe, $runValidation = true)
 
 インターフェース指向メソッドの制御フロー図です。
 
-!\[An example flow for a saveIngredient() method.\](../images/save-component--interface.png =660x1488)
+![An example flow for a saveIngredient() method.](../../images/save-component--interface.png =660x1488)
 
 完全なコードの実例は、次のようになります。
 

--- a/ja/extend/services.md
+++ b/ja/extend/services.md
@@ -78,7 +78,7 @@ Craft には、2つの一般的なモデル操作メソッドがあります。
 
 クラス指向メソッドの制御フロー図です。
 
-![An example flow for a saveRecipe() method.](../../images/save-component--class.png =612x1176)
+![An example flow for a saveRecipe() method.](../../images/save-component--class.png)
 
 ::: tip
 操作が複数データベースの変更を含む場合、データベーストランザクションで操作をラップする必要があるだけです。
@@ -118,7 +118,7 @@ public function saveRecipe(Recipe $recipe, $runValidation = true)
 
 インターフェース指向メソッドの制御フロー図です。
 
-![An example flow for a saveIngredient() method.](../../images/save-component--interface.png =660x1488)
+![An example flow for a saveIngredient() method.](../../images/save-component--interface.png)
 
 完全なコードの実例は、次のようになります。
 


### PR DESCRIPTION
The images in [Japanese plugin/service page](https://docs.craftcms.com/v3/ja/extend/services.html#%E3%82%B5%E3%83%BC%E3%83%93%E3%82%B9%E3%81%A8%E3%81%AF%EF%BC%9F) are not displayed, because the image path is not correct, and resizing doesn't work.
So I adjusted bellow,

- Fix the image path.
- remove the resize description

Thank you.