### PR TITLE
Relations improvements.

### DIFF
--- a/relations.md
+++ b/relations.md
@@ -88,8 +88,7 @@ Passing an array of elements returns results relating to any one of the supplied
 ```twig
 {% set relatedDrinks = craft.entries.section('drinks')
     .relatedTo([ gin, lime ])
-    .all()
-%}
+    .all() %}
 {# result: drinks entries with any relationship to `gin` or `lime` #}
 ```
 
@@ -98,8 +97,7 @@ Passing `and` at the beginning of an array returns results relating to *all* of 
 ```twig
 {% set relatedDrinks = craft.entries.section('drinks')
     .relatedTo([ 'and', gin, lime ])
-    .all()
-%}
+    .all() %}
 {# result: drinks entries with any relationship to `gin` and `lime` #}
 ```
 

--- a/relations.md
+++ b/relations.md
@@ -79,14 +79,18 @@ You can pass one of these things to it:
 A simpler query might pass a single element object or ID, like a `drinks` entry or entry ID represented here by `drink`:
 
 ```twig
-{% set relatedDrinks = craft.entries.section('drinks').relatedTo(drink).all() %}
+{% set relatedDrinks = craft.entries()
+    .section('drinks')
+    .relatedTo(drink)
+    .all() %}
 {# result: drinks entries with *any* relationship to `drink` (source or target) #}
 ```
 
 Passing an array of elements returns results relating to any one of the supplied items:
 
 ```twig
-{% set relatedDrinks = craft.entries.section('drinks')
+{% set relatedDrinks = craft.entries()
+    .section('drinks')
     .relatedTo([ gin, lime ])
     .all() %}
 {# result: drinks entries with any relationship to `gin` or `lime` #}
@@ -95,7 +99,8 @@ Passing an array of elements returns results relating to any one of the supplied
 Passing `and` at the beginning of an array returns results relating to *all* of the supplied items:
 
 ```twig
-{% set relatedDrinks = craft.entries.section('drinks')
+{% set relatedDrinks = craft.entries()
+    .section('drinks')
     .relatedTo([ 'and', gin, lime ])
     .all() %}
 {# result: drinks entries with any relationship to `gin` and `lime` #}
@@ -118,30 +123,39 @@ Only use `sourceSite` if you’ve designated your relational field to be transla
 This is the equivalent of calling `drink.ingredients.all()`:
 
 ```twig
-{% set ingredients = craft.entries.section('ingredients').relatedTo({
-    sourceElement: drink,
-    field: 'ingredients'
-}).all() %}
+{% set ingredients = craft.entries()
+    .section('ingredients')
+    .relatedTo({
+        sourceElement: drink,
+        field: 'ingredients'
+    })
+    .all() %}
 {# result: ingredients entries related from `drink`’s custom `ingredients` field #}
 ```
 
 This doesn’t limit to a specific field, but it limits relations to the current site only:
 
 ```twig
-{% set ingredients = craft.entries.section('ingredients').relatedTo({
-    sourceElement: drink,
-    sourceSite: craft.app.sites.currentSite.id
-}) %}
+{% set ingredients = craft.entries()
+    .section('ingredients')
+    .relatedTo({
+        sourceElement: drink,
+        sourceSite: craft.app.sites.currentSite.id
+    })
+    .all() %}
 {# result: ingredients entries related from `drink`, limited to the current site #}
 ```
 
 This finds other drinks that uses the current one’s primary ingredient:
 
 ```twig
-{% set moreDrinks = craft.entries.section('drinks').relatedTo({
-    targetElement: drink.ingredients.one(),
-    field: 'ingredients'
-}).all() %}
+{% set moreDrinks = craft.entries()
+    .section('drinks')
+    .relatedTo({
+        targetElement: drink.ingredients.one(),
+        field: 'ingredients'
+    })
+    .all() %}
 {# result: other drinks using `drink`’s first ingredient #}
 ```
 
@@ -150,10 +164,13 @@ This finds other drinks that uses the current one’s primary ingredient:
 If you want to find elements related to a source element through a [Matrix](matrix-fields.md) field, pass the Matrix field’s handle to the `field` parameter. If that Matrix field has more than one relational field and you want to target a specific one, you can specify the block type field’s handle using a dot notation:
 
 ```twig
-{% set ingredients = craft.entries.section('ingredients').relatedTo({
-    sourceElement: drink,
-    field: 'ingredientsMatrix.relatedIngredient'
-}).all() %}
+{% set ingredients = craft.entries()
+    .section('ingredients')
+    .relatedTo({
+        sourceElement: drink,
+        field: 'ingredientsMatrix.relatedIngredient'
+    })
+    .all() %}
 ```
 
 #### Passing Multiple Relation Criteria
@@ -161,23 +178,33 @@ If you want to find elements related to a source element through a [Matrix](matr
 There might be times when you need to factor multiple types of relations into the mix. For example, outputting all of the current user’s favorite drinks that include espresso:
 
 ```twig
-{% set espresso = craft.entries.section('ingredients').slug('espresso').one() %}
+{% set espresso = craft.entries()
+    .section('ingredients')
+    .slug('espresso')
+    .one() %}
 
-{% set cocktails = craft.entries.section('drinks').relatedTo(['and',
-    { sourceElement: currentUser, field: 'favoriteDrinks' },
-    { targetElement: espresso, field: 'ingredients' }
-]).all() %}
+{% set cocktails = craft.entries()
+    .section('drinks')
+    .relatedTo(['and',
+        { sourceElement: currentUser, field: 'favoriteDrinks' },
+        { targetElement: espresso, field: 'ingredients' }
+    ])
+    .all() %}
 {# result: current user’s favorite espresso drinks #}
 ```
 
 Or you might want to pass an element query to find other users’ favorite drinks using the current one’s primary ingredient:
 
 ```twig
-{% set otherUsers = craft.users.not(currentUser).all() %}
+{% set otherUsers = craft.users()
+    .not(currentUser)
+    .all() %}
 
-{% set recommendedCocktails = craft.entries.section('drinks').relatedTo(['and',
-    { sourcElement: otherUsers, field: 'favoriteDrinks' },
-    { targetElement: drink.ingredients.one(), field: 'ingredients' }
-]) %}
+{% set recommendedCocktails = craft.entries()
+    .section('drinks').relatedTo(['and',
+        { sourcElement: otherUsers, field: 'favoriteDrinks' },
+        { targetElement: drink.ingredients.one(), field: 'ingredients' }
+    ])
+    .all() %}
 {# result: other users’ favorite drinks that use `drink`’s first ingredient #}
 ```

--- a/relations.md
+++ b/relations.md
@@ -121,7 +121,7 @@ This is the equivalent of calling `drink.ingredients.all()`:
 {% set ingredients = craft.entries.section('ingredients').relatedTo({
     sourceElement: drink,
     field: 'ingredients'
-}) %}
+}).all() %}
 {# result: ingredients entries related from `drink`’s custom `ingredients` field #}
 ```
 
@@ -141,7 +141,7 @@ This finds other drinks that uses the current one’s primary ingredient:
 {% set moreDrinks = craft.entries.section('drinks').relatedTo({
     targetElement: drink.ingredients.one(),
     field: 'ingredients'
-}) %}
+}).all() %}
 {# result: other drinks using `drink`’s first ingredient #}
 ```
 

--- a/relations.md
+++ b/relations.md
@@ -37,7 +37,7 @@ Once we have our relations field set up, we can look at the options for outputti
 
 If you’ve already got a hold of the source element in your template, like in the example below where we're outputting the Drink entry, you can access its target elements for a particular field in the same way you access any other field’s value: by the handle.
 
-Calling the source’s relational field handle (`ingredients`) returns an Element Criteria Model that can output the field’s target elements, in the field-defined order.
+Calling the source’s relational field handle (`ingredients`) returns an [entry query](dev/element-queries/entry-queries.md) that can output the field’s target elements, in the field-defined order.
 
 If we want to output the ingredients list for a drink recipe, we'd use the following:
 
@@ -71,8 +71,8 @@ You can pass one of these things to it:
 
 - A single **element object**: <api:craft\elements\Asset>, <api:craft\elements\Category>, <api:craft\elements\Entry>, <api:craft\elements\User>, or <api:craft\elements\Tag>
 - A single **element ID**
-- A **hash** with properties we’ll get into below: `element`, `sourceElement` or `targetElement` optionally with `field` and/or `sourceSite`
-- An **array** containing any mixture of the above options, which can start with `and` for relations on all elements rather than *any* elements (default behavior is `or`, which you can omit or pass explicitly)
+- A [**hash**](dev/twig-primer.md#hashes) with properties we’ll get into below: `element`, `sourceElement` or `targetElement` optionally with `field` and/or `sourceSite`
+- An [**array**](dev/twig-primer.md#arrays) containing any mixture of the above options, which can start with `and` for relations on all elements rather than _any_ elements (default behavior is `or`, which you can omit or pass explicitly)
 
 #### Simple Relationships
 

--- a/relations.md
+++ b/relations.md
@@ -185,7 +185,8 @@ There might be times when you need to factor multiple types of relations into th
 
 {% set cocktails = craft.entries()
     .section('drinks')
-    .relatedTo(['and',
+    .relatedTo([
+        'and',
         { sourceElement: currentUser, field: 'favoriteDrinks' },
         { targetElement: espresso, field: 'ingredients' }
     ])
@@ -202,7 +203,8 @@ Or you might want to pass an element query to find other users’ favorite drink
 
 {% set recommendedCocktails = craft.entries()
     .section('drinks')
-    .relatedTo(['and',
+    .relatedTo([
+        'and',
         { sourcElement: otherUsers, field: 'favoriteDrinks' },
         { targetElement: drink.ingredients.one(), field: 'ingredients' }
     ])

--- a/relations.md
+++ b/relations.md
@@ -201,7 +201,8 @@ Or you might want to pass an element query to find other users’ favorite drink
     .all() %}
 
 {% set recommendedCocktails = craft.entries()
-    .section('drinks').relatedTo(['and',
+    .section('drinks')
+    .relatedTo(['and',
         { sourcElement: otherUsers, field: 'favoriteDrinks' },
         { targetElement: drink.ingredients.one(), field: 'ingredients' }
     ])


### PR DESCRIPTION
Goals:

- Edit for brevity and clarity.
- Exhaustively list and describe `relatedTo` parameters in one place.
- Explain and demonstrate previously-undocumented ability to pass element queries.
- Note option to pass handle to `sourceSite`.
- Reiterate expected result of each example.
- Clarify default array `or` behavior and mention toward the beginning rather than the end.