### PR TITLE
Fix event type used to register custom exporter

### DIFF
--- a/extend/element-exporter-types.md
+++ b/extend/element-exporter-types.md
@@ -114,7 +114,7 @@ namespace ns\prefix;
 
 use craft\base\Element;
 use craft\elements\Entry;
-use craft\events\RegisterElementActionsEvent;
+use craft\events\RegisterElementExportersEvent;
 use yii\base\Event;
 
 class Plugin extends \craft\base\Plugin


### PR DESCRIPTION
In the custom exporter type documentation, the example code for registering a custom exporter type contained `use craft\events\RegisterElementActionsEvent` instead of `use craft\events\RegisterElementExportersEvent`.