### PR TITLE
Added documentation for nav item active states

### DIFF
--- a/extend/cp-section.md
+++ b/extend/cp-section.md
@@ -36,8 +36,7 @@ Each item within the [navItems](api:craft\events\RegisterCpNavItemsEvent::$navIt
 - `subnav` _(optional)_ – An array of subnav items that should be visible when your section is accessed. (See [Subnavs](#subnavs).)
 
 
-The `url` property must be registered with a relative path to the plugin or module's section in the Control Panel in order for Craft to properly determine which nav item to designate as "active." Further, your subnav paths should begin with this same nav item's path in order for the item to appear selected when a subnav item is active.
-
+For Craft to properly designate an item as “active,” its `url` must be registered with a relative path to the plugin or module’s control panel section. Any `subnav` paths should begin with `url` in order to appear selected when active.
 
 ## Subnavs
 

--- a/extend/cp-section.md
+++ b/extend/cp-section.md
@@ -35,6 +35,10 @@ Each item within the [navItems](api:craft\events\RegisterCpNavItemsEvent::$navIt
 - `badgeCount` _(optional)_ – The badge count that should be displayed in the nav item.
 - `subnav` _(optional)_ – An array of subnav items that should be visible when your section is accessed. (See [Subnavs](#subnavs).)
 
+
+The `url` property must be registered with a relative path to the plugin or module's section in the Control Panel in order for Craft to properly determine which nav item to designate as "active." Further, your subnav paths should begin with this same nav item's path in order for the item to appear selected when a subnav item is active.
+
+
 ## Subnavs
 
 If your section has a sub-navigation, each subnav item within your `subnav` array should be represented by a sub-array with `url` and `label` keys:


### PR DESCRIPTION
### Description
Adds documentation to explain how Craft determines which nav item to mark as active.
