### PR TITLE
Add tip for password resets in Headless Mode

### DIFF
--- a/config/config-settings.md
+++ b/config/config-settings.md
@@ -1097,8 +1097,7 @@ Since
 
 
 
-Bool Whether the system should run in Headless Mode, which
-optimizes the system and control panel for headless CMS implementations.
+Whether the system should run in Headless Mode, which optimizes the system and control panel for headless CMS implementations.
 
 When this is enabled, the following changes will take place:
 
@@ -1106,11 +1105,12 @@ When this is enabled, the following changes will take place:
 - Template route management will be hidden.
 - Front-end routing will skip checks for element and template requests.
 - Front-end responses will be JSON-formatted rather than HTML by default.
-- Twig will be configured to escape unsafe strings for JavaScript/JSON
-  rather than HTML by default for front-end requests.
-- The <config:loginPath>, <config:logoutPath>, <config:setPasswordPath>, and
-  <config:verifyEmailPath> settings will be ignored.
+- Twig will be configured to escape unsafe strings for JavaScript/JSON rather than HTML by default for front-end requests.
+- The <config:loginPath>, <config:logoutPath>, <config:setPasswordPath>, and <config:verifyEmailPath> settings will be ignored.
 
+::: tip
+When Headless Mode is enabled, users will not be able to set an initial password, set a new password, or verify their email address unless they have the "Access the control panel" permission. Make sure to grant this permission to content editors and administrators who should be able to log into the control panel.
+:::
 
 
 ### `imageDriver`
@@ -1129,8 +1129,7 @@ Defined by
 
 
 
-The image driver Craft should use to cleanse and transform images. By default Craft will auto-detect if ImageMagick is installed and fallback to GD if not. You can explicitly set
-either `'imagick'` or `'gd'` here to override that behavior.
+The image driver Craft should use to cleanse and transform images. By default Craft will auto-detect if ImageMagick is installed and fallback to GD if not. You can explicitly set either `'imagick'` or `'gd'` here to override that behavior.
 
 
 

--- a/dev/headless.md
+++ b/dev/headless.md
@@ -4,6 +4,8 @@ Craft’s templating system isn’t the only way to get your content out of Craf
 
 If you want to use Craft as a “headless” CMS, meaning it acts as a content API instead of (or in addition to) a regular website, there are a few ways you can go about it.
 
+To see exactly what enabling Headless Mode does, see the [`headlessMode` config setting](../config/config-settings.md#headlessmode).
+
 ::: tip
 Check out CraftQuest’s [Headless Craft CMS](https://craftquest.io/courses/headless-craft) course to learn more about using Craft as a headless CMS.
 :::


### PR DESCRIPTION
- Add tip to `headlessMode` config setting documentation which clarifies
  the required permission for user accounts in order for a user to set
  their password.
- Add pointer to `headlessMode` config setting on the "Going Headless"
  guide.

**Note:** "bool bool" in [craftcms/cms/src/config/GeneralConfig.php:381](https://github.com/craftcms/cms/blob/e7919cddd0a918e1680e26b3038778d5fc851a8e/src/config/GeneralConfig.php#L381) should also be changed to "bool". Someone want to sneak that in without me needing to make another PR? 😉

### Related issues

- craftcms/cms#6226