### PR TITLE
Update category-queries.md

### DIFF
--- a/dev/element-queries/category-queries.md
+++ b/dev/element-queries/category-queries.md
@@ -529,7 +529,7 @@ Possible values include:
 | `1` | with an ID of 1.
 | `'not 1'` | not with an ID of 1.
 | `[1, 2]` | with an ID of 1 or 2.
-| `['not', 1, 2]` | not with an ID of 1 or 2.
+| `['not, 1, 2, 7']` | not with an ID of 1, 2 or 7.
 
 
 


### PR DESCRIPTION
Misplaced Apostrophe, throws a twig error as written `['not', 1, 2]`.

### Description



### Related issues

